### PR TITLE
Fix download completion detection

### DIFF
--- a/backend/downloader.py
+++ b/backend/downloader.py
@@ -53,6 +53,17 @@ class Downloader:
             elif d.get("status") == "finished":
                 if progress_callback:
                     progress_callback(1.0)
+                if (
+                    d.get("info_dict", {}).get("requested_formats") is None
+                    and finished_callback
+                ):
+                    finished_callback()
+
+        def _pp_hook(d):
+            if (
+                d.get("status") == "finished"
+                and "merger" in d.get("postprocessor", "").lower()
+            ):
                 if finished_callback:
                     finished_callback()
 
@@ -61,6 +72,7 @@ class Downloader:
             "format": format_id.split(" - ")[0],
             "outtmpl": str(output_template),
             "progress_hooks": [_hook],
+            "postprocessor_hooks": [_pp_hook],
         }
         ffmpeg_dir = Downloader._get_ffmpeg_dir()
         if ffmpeg_dir and not shutil.which("ffmpeg"):

--- a/gui/app.py
+++ b/gui/app.py
@@ -33,6 +33,9 @@ class App(ctk.CTk):
         self.checkbox_var = ctk.BooleanVar()
         self.checkbox_var.set(True)
 
+        # flag to indicate an ongoing download
+        self.downloading = False
+
         self.message_label = None
         MyYouTubeDownloaderApp(self)
 
@@ -42,7 +45,7 @@ class App(ctk.CTk):
             row=6,
             column=0,
             padx=10,
-            pady=(0, 10),
+            pady=(0, 20),
             sticky="ew",
         )
         self.progress_bar.grid_remove()
@@ -131,7 +134,7 @@ class App(ctk.CTk):
 
     def update_download_button(self, *args) -> None:
         """Enable or disable download button based on selection."""
-        if self.selected_format.get():
+        if self.selected_format.get() and not self.downloading:
             self.download_button.configure(state="normal")
         else:
             self.download_button.configure(state="disabled")
@@ -148,6 +151,7 @@ class App(ctk.CTk):
 
         info = Downloader.search_video(self.URL_Entry.get())
         self.download_button.configure(state="disabled")
+        self.downloading = True
         self.progress_bar.set(0)
         self.progress_bar.grid()
         self.show_message("Downloading video...", "green")
@@ -187,7 +191,9 @@ class App(ctk.CTk):
 
     def _on_download_finished(self) -> None:
         """Re-enable UI elements and show completion message."""
-        self.download_button.configure(state="normal")
+        self.downloading = False
+        # restore download button state based on current selection
+        self.update_download_button()
         self.progress_bar.grid_remove()
         self.show_message("Download finished!", "green")
 


### PR DESCRIPTION
## Summary
- trigger download completion only after merge stage finishes
- space below progress bar so it's not flush with window edge

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68421f30adc08321a0a1611826c26f64