### PR TITLE
Use pytube for multithreaded downloads

### DIFF
--- a/backend/downloader.py
+++ b/backend/downloader.py
@@ -2,8 +2,11 @@
 
 from pathlib import Path
 import shutil
+import threading
+import subprocess
+import tempfile
 
-import yt_dlp
+from pytube import YouTube
 
 
 class Downloader:
@@ -22,17 +25,26 @@ class Downloader:
 
     @staticmethod
     def search_video(url: str) -> dict:
-        """Return video information without downloading."""
-        ydl_opts = {
-            "quiet": True,
-            "simulate": True,
-            "force_generic_extractor": True,
+        """Return basic video information using pytube."""
+        yt = YouTube(url)
+        info = {
+            "title": yt.title,
+            "webpage_url": url,
+            "formats": [],
         }
-        ffmpeg_dir = Downloader._get_ffmpeg_dir()
-        if ffmpeg_dir and not shutil.which("ffmpeg"):
-            ydl_opts["ffmpeg_location"] = str(ffmpeg_dir)
-        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-            return ydl.extract_info(url, download=False)
+        for stream in yt.streams.filter(adaptive=True):
+            fmt = {
+                "format_id": str(stream.itag),
+                "vcodec": stream.video_codec or "none",
+                "acodec": stream.audio_codec or "none",
+                "resolution": stream.resolution,
+                "abr": int(stream.abr.replace("kbps", "")) if stream.abr else None,
+                "tbr": int(stream.bitrate / 1000) if stream.bitrate else None,
+                "height": int(stream.resolution.rstrip("p")) if stream.resolution else None,
+                "language_preference": 0,
+            }
+            info["formats"].append(fmt)
+        return info
 
     @staticmethod
     def download_video(
@@ -42,40 +54,87 @@ class Downloader:
         progress_callback=None,
         finished_callback=None,
     ) -> None:
-        """Download the selected format to the given path."""
+        """Download the selected format to the given path using pytube."""
 
-        def _hook(d):
-            if d.get("status") == "downloading":
-                total = d.get("total_bytes") or d.get("total_bytes_estimate") or 0
-                downloaded = d.get("downloaded_bytes", 0)
-                if progress_callback and total:
-                    progress_callback(downloaded / total)
-            elif d.get("status") == "finished":
-                if progress_callback:
-                    progress_callback(1.0)
-                if (
-                    d.get("info_dict", {}).get("requested_formats") is None
-                    and finished_callback
-                ):
-                    finished_callback()
+        yt = YouTube(info["webpage_url"])
 
-        def _pp_hook(d):
-            if (
-                d.get("status") == "finished"
-                and "merger" in d.get("postprocessor", "").lower()
-            ):
-                if finished_callback:
-                    finished_callback()
+        ids = format_id.split("+")
+        video_stream = yt.streams.get_by_itag(int(ids[0]))
+        audio_stream = yt.streams.get_by_itag(int(ids[1])) if len(ids) > 1 else None
 
-        output_template = Path(save_path) / "%(title)s.%(ext)s"
-        ydl_opts = {
-            "format": format_id.split(" - ")[0],
-            "outtmpl": str(output_template),
-            "progress_hooks": [_hook],
-            "postprocessor_hooks": [_pp_hook],
-        }
+        tmp_dir = tempfile.TemporaryDirectory()
+        video_file = Path(tmp_dir.name) / "video.mp4"
+        audio_file = Path(tmp_dir.name) / "audio.mp4"
+
+        total_size = (video_stream.filesize or 0) + ((audio_stream.filesize or 0) if audio_stream else 0)
+        progress = {"video": 0, "audio": 0}
+
+        def make_callback(key):
+            def _cb(stream, chunk, bytes_remaining):
+                progress[key] = stream.filesize - bytes_remaining
+                if progress_callback and total_size:
+                    downloaded = progress["video"] + progress.get("audio", 0)
+                    progress_callback(downloaded / total_size)
+            return _cb
+
+        threads = []
+        threads.append(
+            threading.Thread(
+                target=video_stream.download,
+                kwargs={
+                    "output_path": tmp_dir.name,
+                    "filename": "video",
+                    "on_progress_callback": make_callback("video"),
+                },
+            )
+        )
+        if audio_stream:
+            threads.append(
+                threading.Thread(
+                    target=audio_stream.download,
+                    kwargs={
+                        "output_path": tmp_dir.name,
+                        "filename": "audio",
+                        "on_progress_callback": make_callback("audio"),
+                    },
+                )
+            )
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        ffmpeg_bin = shutil.which("ffmpeg")
         ffmpeg_dir = Downloader._get_ffmpeg_dir()
-        if ffmpeg_dir and not shutil.which("ffmpeg"):
-            ydl_opts["ffmpeg_location"] = str(ffmpeg_dir)
-        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-            ydl.download([info["webpage_url"]])
+        if not ffmpeg_bin and ffmpeg_dir:
+            ffmpeg_bin = str(Path(ffmpeg_dir) / "ffmpeg")
+
+        output_file = Path(save_path) / f"{yt.title}.mp4"
+
+        def merge():
+            if audio_stream:
+                subprocess.run(
+                    [
+                        ffmpeg_bin,
+                        "-y",
+                        "-i",
+                        str(video_file),
+                        "-i",
+                        str(audio_file),
+                        "-c",
+                        "copy",
+                        str(output_file),
+                    ],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            else:
+                shutil.move(str(video_file), str(output_file))
+            tmp_dir.cleanup()
+            if finished_callback:
+                finished_callback()
+
+        merge_thread = threading.Thread(target=merge)
+        merge_thread.start()
+        merge_thread.join()

--- a/backend/downloader.py
+++ b/backend/downloader.py
@@ -26,12 +26,17 @@ class Downloader:
     @staticmethod
     def search_video(url: str) -> dict:
         """Return basic video information using pytube."""
-        yt = YouTube(url)
+        try:
+            yt = YouTube(url)
+        except Exception as exc:  # network errors, invalid URLs, etc
+            raise ValueError("Unable to retrieve video information") from exc
+
         info = {
             "title": yt.title,
             "webpage_url": url,
             "formats": [],
         }
+
         for stream in yt.streams.filter(adaptive=True):
             fmt = {
                 "format_id": str(stream.itag),
@@ -56,7 +61,10 @@ class Downloader:
     ) -> None:
         """Download the selected format to the given path using pytube."""
 
-        yt = YouTube(info["webpage_url"])
+        try:
+            yt = YouTube(info["webpage_url"])
+        except Exception as exc:
+            raise ValueError("Unable to retrieve video") from exc
 
         ids = format_id.split("+")
         video_stream = yt.streams.get_by_itag(int(ids[0]))

--- a/backend/downloader.py
+++ b/backend/downloader.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 
 from pytube import YouTube
+from pytube.exceptions import RegexMatchError, VideoUnavailable
 
 
 class Downloader:
@@ -28,8 +29,10 @@ class Downloader:
         """Return basic video information using pytube."""
         try:
             yt = YouTube(url)
+        except (RegexMatchError, VideoUnavailable) as exc:
+            raise ValueError("Video unavailable or invalid") from exc
         except Exception as exc:  # network errors, invalid URLs, etc
-            raise ValueError("Unable to retrieve video information") from exc
+            raise ValueError(f"Network error: {exc}") from exc
 
         info = {
             "title": yt.title,
@@ -63,8 +66,10 @@ class Downloader:
 
         try:
             yt = YouTube(info["webpage_url"])
+        except (RegexMatchError, VideoUnavailable) as exc:
+            raise ValueError("Video unavailable or invalid") from exc
         except Exception as exc:
-            raise ValueError("Unable to retrieve video") from exc
+            raise ValueError(f"Network error: {exc}") from exc
 
         ids = format_id.split("+")
         video_stream = yt.streams.get_by_itag(int(ids[0]))

--- a/gui/app.py
+++ b/gui/app.py
@@ -61,9 +61,10 @@ class App(ctk.CTk):
             info = Downloader.search_video(url)
             self.display_streams(info)
             self.show_message("Video found. Select a stream to download.")
-        except Exception:
+        except Exception as exc:
             self.show_message(
-                "Video not found. Please check the URL and try again."
+                f"Error: {exc}. Please check the URL or your connection.",
+                "red",
             )
 
     def display_streams(self, info: dict) -> None:

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,9 @@ The application automatically uses it if no system FFmpeg is found.
 3. Choose the desired resolution.
 4. The video will be downloaded to the current directory.
 
+If the application reports a network error (e.g. "HTTP Error 400"), ensure that
+your environment allows outbound HTTPS connections to YouTube.
+
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request for any changes.

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ This project is a simple YouTube video downloader built with Python. It allows u
 ## Requirements
 
 - Python 3.x
-- `yt-dlp` library
+- `pytube` library
 
 ## Installation
 
@@ -51,3 +51,4 @@ Contributions are welcome! Please open an issue or submit a pull request for any
 ## Contact
 
 For any questions or suggestions, please contact trehen30@gmail.com.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-yt-dlp
+pytube
 customtkinter
+


### PR DESCRIPTION
## Summary
- refactor backend to use pytube instead of yt-dlp
- spawn threads for audio/video downloads and merging
- update requirements and docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b49b49f0c8321bde53eb1fb3c68d8