### PR TITLE
Fix ffmpeg args for Merger

### DIFF
--- a/backend/downloader.py
+++ b/backend/downloader.py
@@ -107,8 +107,9 @@ class Downloader:
             "outtmpl": str(output),
             "concurrent_fragment_downloads": os.cpu_count() or 1,
             "restrictfilenames": True,
+            "merge_output_format": "mkv",  # evita erro ao mesclar Opus
+            "verbose": True,
         }
-        ydl_opts["merge_output_format"] = "mkv"       # evita erro ao mesclar Opus
         ffmpeg_path = shutil.which("ffmpeg")
         ffmpeg_dir = Downloader._get_ffmpeg_dir()
         if not ffmpeg_path and ffmpeg_dir:
@@ -118,11 +119,13 @@ class Downloader:
             hwaccel = _hwaccel_args(ffmpeg_path)
         else:
             hwaccel = []
-        ydl_opts["postprocessor_args"] = [
-            "-threads",
-            str(os.cpu_count() or 1),
-            *hwaccel,
-        ]
+        ydl_opts["postprocessor_args"] = {
+            "Merger+ffmpeg": [
+                "-threads",
+                str(os.cpu_count() or 1),
+                *hwaccel,
+            ]
+        }
         return ydl_opts
 
 


### PR DESCRIPTION
## Summary
- apply ffmpeg flags only to the merger
- ensure options use merge_output_format `mkv` and set verbose mode

## Testing
- `python -m py_compile backend/downloader.py`

------
https://chatgpt.com/codex/tasks/task_e_688b688189108321be4b498312cea02a