### PR TITLE
Fix ffmpeg merger options

### DIFF
--- a/backend/downloader.py
+++ b/backend/downloader.py
@@ -118,11 +118,14 @@ class Downloader:
             hwaccel = _hwaccel_args(ffmpeg_path)
         else:
             hwaccel = []
-        ydl_opts["postprocessor_args"] = [
-            "-threads",
-            str(os.cpu_count() or 1),
-            *hwaccel,
-        ]
+        ydl_opts["verbose"] = True
+        ydl_opts["postprocessor_args"] = {
+            "Merger+ffmpeg": [
+                "-threads",
+                str(os.cpu_count() or 1),
+                *hwaccel,
+            ]
+        }
         return ydl_opts
 
 


### PR DESCRIPTION
## Summary
- only apply `-threads` and `-hwaccel` to the merging postprocessor
- enable verbose output for easier debugging

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b688189108321be4b498312cea02a