### PR TITLE
Improve status messages

### DIFF
--- a/backend/downloader.py
+++ b/backend/downloader.py
@@ -150,11 +150,23 @@ class Downloader:
         save_path: str,
         progress_callback=None,
         finished_callback=None,
+        stage_callback=None,
     ) -> None:
         """Download the selected format to the given path."""
 
+        current_stage = [None]
+
         def _hook(d):
             if d.get("status") == "downloading":
+                info_dict = d.get("info_dict", {})
+                stage = None
+                if info_dict.get("vcodec") != "none" and info_dict.get("acodec") == "none":
+                    stage = "Downloading video..."
+                elif info_dict.get("acodec") != "none" and info_dict.get("vcodec") == "none":
+                    stage = "Downloading audio..."
+                if stage_callback and stage and stage != current_stage[0]:
+                    current_stage[0] = stage
+                    stage_callback(stage)
                 total = d.get("total_bytes") or d.get("total_bytes_estimate") or 0
                 downloaded = d.get("downloaded_bytes", 0)
                 if progress_callback and total:
@@ -169,12 +181,13 @@ class Downloader:
                     finished_callback()
 
         def _pp_hook(d):
-            if (
-                d.get("status") == "finished"
-                and "merger" in d.get("postprocessor", "").lower()
-            ):
-                if finished_callback:
-                    finished_callback()
+            if "merger" in d.get("postprocessor", "").lower():
+                if d.get("status") == "started":
+                    if stage_callback:
+                        stage_callback("Merging...")
+                elif d.get("status") == "finished":
+                    if finished_callback:
+                        finished_callback()
 
         output_template = Path(save_path) / "%(title)s.%(ext)s"
         ydl_opts = Downloader._build_ydl_opts(format_id, output_template)

--- a/gui/app.py
+++ b/gui/app.py
@@ -129,13 +129,14 @@ class App(ctk.CTk):
         self.downloading = True
         self.progress_bar.set(0)
         self.progress_bar.grid()
-        self.show_message("Downloading video...", "green")
+        self.show_message("Starting download...", "green")
         Downloader.download_video(
             self.video_info,
             selected_stream,
             save_path,
             self._progress_callback,
             self._download_finished_callback,
+            self._stage_callback,
         )
 
     def show_message(self, message: str, color: str = "white") -> None:
@@ -154,6 +155,10 @@ class App(ctk.CTk):
     def _progress_callback(self, progress: float) -> None:
         """Thread-safe update of the progress bar."""
         self.after(0, lambda p=progress: self.progress_bar.set(p))
+
+    def _stage_callback(self, stage: str) -> None:
+        """Thread-safe update of the status message."""
+        self.after(0, lambda s=stage: self.show_message(s, "green"))
 
     def _download_finished_callback(self) -> None:
         """Schedule UI updates when a download completes."""


### PR DESCRIPTION
## Summary
- add stage callback support in `Downloader.download_video`
- update `App` to show intermediate steps during the download

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b70e820d08321b1a6fb0b48ea87c4